### PR TITLE
Detect 13C/2H isotopes and fix isotopes widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][]
 ### Added
+-   Detect dual 13C/2H labeled isotopes @lparsons
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased][]
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+-   Fixed isotopes widget to display only those isotopes that correspond the
+    isotopes selected in the application preferences (i.e. if C13 is not
+    selected in preferences, then no C13 isotopes will be displayed). @lparsons
+
+### Security
+
+
 ## [8.0.0][] - 2017-08-28
 ### Added
 -   Build process automated using Travis and Appveyor @lparsons
@@ -25,6 +42,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [20161028][] - 2016-10-28
 -   TODO - Document changes
 
-
+[Unreleased]: https://github.com/eugenemel/maven/compare/8.0.0...HEAD
 [8.0.0]: https://github.com/eugenemel/maven/compare/20161028...8.0.0
 [20161028]: https://github.com/eugenemel/maven/compare/92cf1d16dfc7d9f6bf4394890a06c3ecbed2ba1a...20161028


### PR DESCRIPTION
Uses the updated maven_core that detects 13C/2H isotopes. Also fixes the isotopes widget so that it displays only those isotopes that correspond the isotopes selected in the application preferences (i.e. if C13 is not selected in preferences, then no C13 isotopes will be displayed).